### PR TITLE
Fix the calculation of confidence intervals

### DIFF
--- a/Functions/IC.R
+++ b/Functions/IC.R
@@ -2,9 +2,8 @@
 IC <- function(X, conf.level = 0.95){
   m <- mean(X)
   s <- sd(X)
-  n <- length(X)
-  se <- s/sqrt(n)
-  error <- qt((1-conf.level)/2, df = n-1, lower.tail = FALSE)*se
-  res <- c(mean = m, sd = s, lower = m-error, upper = m+error)
+  tails <- (1 - conf.level)/2
+  ic <- as.numeric(quantile(X, probs = c(tails, 1 - tails)))
+  res <- c(mean = m, sd = s, lower = ic[1], upper = ic[2])
   return(res)
 }


### PR DESCRIPTION
Replaces the method of calculation of confidence intervals. Instead of assuming a t distribution on the standard error, which does not work for randomizations and assumes a normal distribution of the randomized values, this change uses the quantiles of the randomized distribution directly.